### PR TITLE
Fix cache removal on network errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,10 +10,11 @@ export default function memoizedNodeFetchFactory(fetchFunction: FetchFunctionTyp
     const promiseCache: Map<number, Promise<Response>> = new Map();
 
     async function wrapper(key: number, promise: Promise<Response>) {
-        await promise;
-
-        promiseCache.delete(key);
-
+        try {
+            await promise;
+        } finally {
+            promiseCache.delete(key);
+        }
         return promise;
     }
 

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -4,7 +4,11 @@ import memoizedNodeFetch, { FetchFunctionType } from '../src';
 
 function testFetch(url: RequestInfo, options?: RequestInit | undefined): Promise<Response> {
     return new Promise((resolve, reject) => {
-        setTimeout(() => resolve({} as Response), 10);
+        setTimeout(
+            () =>
+                url === 'fail' ? reject(new Error('Network Unreachable')) : resolve({} as Response),
+            10
+        );
     });
 }
 
@@ -48,6 +52,15 @@ describe('MemoizedNodeFetch', () => {
 
         await promise1;
         const promise2 = fetch('test');
+
+        expect(promise1).to.not.be.equal(promise2);
+    });
+
+    it('Deletes a promise from the cache after it rejects', async () => {
+        const promise1 = fetch('fail');
+
+        await promise1.catch(() => {});
+        const promise2 = fetch('fail');
 
         expect(promise1).to.not.be.equal(promise2);
     });


### PR DESCRIPTION
At the moment, when a network error occurs, fetch will give an rejected promise, instead of of a Promise holding a Response object.

This creates an issue with the current implementation of the cache, which doesn't handle rejections, and in turn never removes it from cache. In practice, this causes a problem that once there is a network error, that cache entry is effectively "poisoned", and will always give the network error.

This addresses this issue by making sure it always gets removed from the cache, even in the event of an error.

Note that this can also be solved by a one-lines like `return promise.finally(() => promiseCache.delete(key));`, I have decided for this way as it is easier to read, and software is read more times than it is written (and it also mirrors the style of the rest of the code)

(I originally found a link to project from reddit, and decided to use it in some of my private projects, instead of a self written solution)