### PR TITLE
Add the option to use custom hash function

### DIFF
--- a/docs/globals.html
+++ b/docs/globals.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>memoized-node-fetch - v1.0.1</title>
+	<title>memoized-node-fetch - v1.0.2</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="assets/css/main.css">
@@ -22,7 +22,7 @@
 						<li class="state loading">Preparing search index...</li>
 						<li class="state failure">The search index is not available</li>
 					</ul>
-					<a href="index.html" class="title">memoized-node-fetch - v1.0.1</a>
+					<a href="index.html" class="title">memoized-node-fetch - v1.0.2</a>
 				</div>
 				<div class="table-cell" id="tsd-widgets">
 					<div id="tsd-filter">
@@ -54,7 +54,7 @@
 					<a href="globals.html">Globals</a>
 				</li>
 			</ul>
-			<h1>memoized-node-fetch - v1.0.1</h1>
+			<h1>memoized-node-fetch - v1.0.2</h1>
 		</div>
 	</div>
 </header>
@@ -88,7 +88,7 @@
 					<div class="tsd-signature tsd-kind-icon">Fetch<wbr>Function<wbr>Type<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span>url<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">RequestInfo</span>, init<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">RequestInit</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Response</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/chrispanag/memoized-node-fetch/blob/9eb416d/src/index.ts#L4">index.ts:4</a></li>
+							<li>Defined in <a href="https://github.com/Nikpolik/memoized-node-fetch/blob/04f2e17/src/index.ts#L4">index.ts:4</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-type-declaration">
@@ -129,7 +129,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/chrispanag/memoized-node-fetch/blob/9eb416d/src/index.ts#L9">index.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/Nikpolik/memoized-node-fetch/blob/04f2e17/src/index.ts#L9">index.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>memoized-node-fetch - v1.0.1</title>
+	<title>memoized-node-fetch - v1.0.2</title>
 	<meta name="description" content="">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" href="assets/css/main.css">
@@ -22,7 +22,7 @@
 						<li class="state loading">Preparing search index...</li>
 						<li class="state failure">The search index is not available</li>
 					</ul>
-					<a href="index.html" class="title">memoized-node-fetch - v1.0.1</a>
+					<a href="index.html" class="title">memoized-node-fetch - v1.0.2</a>
 				</div>
 				<div class="table-cell" id="tsd-widgets">
 					<div id="tsd-filter">
@@ -54,7 +54,7 @@
 					<a href="globals.html">Globals</a>
 				</li>
 			</ul>
-			<h1>memoized-node-fetch - v1.0.1</h1>
+			<h1>memoized-node-fetch - v1.0.2</h1>
 		</div>
 	</div>
 </header>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "chai": "^4.2.0",
         "mocha": "^8.1.3",
         "prettier": "^2.1.2",
-        "ts-mocha": "^7.0.0",
+        "ts-mocha": "^8.0.0",
         "tslint": "^6.1.3",
         "typedoc": "^0.17.0-3",
         "typescript": "^4.0.2"

--- a/src/hasher.ts
+++ b/src/hasher.ts
@@ -1,4 +1,12 @@
-export default function stringToHash(string: string) {
+import { RequestInit, RequestInfo } from 'node-fetch';
+
+export type HashFunction = (url: RequestInfo, options?: RequestInit) => number;
+
+export default function requestToHash(url: RequestInfo, options?: RequestInit) {
+    return stringToHash(url.toString() + JSON.stringify(options));
+}
+
+function stringToHash(string: string) {
     let hash = 0;
 
     if (string.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import fetch, { RequestInfo, RequestInit, Response } from 'node-fetch';
-import stringToHash from './hasher';
+import requestToHash, { HashFunction } from './hasher';
 
 export type FetchFunctionType = (
     url: RequestInfo,
@@ -18,8 +18,12 @@ export default function memoizedNodeFetchFactory(fetchFunction: FetchFunctionTyp
         return promise;
     }
 
-    function wrappedFetch(url: RequestInfo, options?: RequestInit) {
-        const key = stringToHash(url.toString() + JSON.stringify(options));
+    function wrappedFetch(
+        url: RequestInfo,
+        options?: RequestInit,
+        hashFunction: HashFunction = requestToHash
+    ) {
+        const key = hashFunction(url, options);
         if (promiseCache.has(key)) {
             return promiseCache.get(key);
         }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -3,15 +3,16 @@ import { RequestInfo, RequestInit, Response } from 'node-fetch';
 import memoizedNodeFetch, { FetchFunctionType } from '../src';
 
 function testFetch(url: RequestInfo, options?: RequestInit | undefined): Promise<Response> {
-    return new Promise((resolve, reject) => setTimeout(() => {
-        switch (url) {
-            case 'fail':
-                return reject(new Error('Network Unreachable'));
-            default:
-                return resolve({} as Response);
-        }
-        resolve({} as Response)
-    }, 10));
+    return new Promise((resolve, reject) =>
+        setTimeout(() => {
+            switch (url) {
+                case 'fail':
+                    return reject(new Error('Network Unreachable'));
+                default:
+                    return resolve({} as Response);
+            }
+        }, 100)
+    );
 }
 
 describe('MemoizedNodeFetch', () => {
@@ -34,19 +35,23 @@ describe('MemoizedNodeFetch', () => {
         }
     });
 
-    it('Will return the same promise for requests with the same key and different with other', async () => {
+    it('Will return the same promise for requests with the same key', async () => {
         const promise1 = fetch('test');
         const promise2 = fetch('test');
         const promise3 = fetch('test');
-        const promise4 = fetch('test_different');
 
         const resultsEqual = [promise1, promise2, promise3];
 
         for (const r of resultsEqual) {
             expect(r).to.be.equal(promise1);
         }
+    });
 
-        expect(promise4).to.not.be.equal(promise1);
+    it('Will return different promises for different keys', async () => {
+        const promise = fetch('test');
+        const differentPromise = fetch('test_different');
+
+        expect(promise).to.not.be.equal(differentPromise);
     });
 
     it('Deletes a promise from the cache after it resolves', async () => {


### PR DESCRIPTION
## What
Add the option to use a different hash generator function

## Why
There are cases where hashing the whole options object is overkill. For example, maybe not all headers are important as they could include metadata that changes from request to request.
